### PR TITLE
Bring entire application into one process

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -4,30 +4,31 @@
  * Bootstraps the full chatbot, including the conversation and management API, with default config.
  */
 
-const spawn = require("child_process").spawn;
 const path = require("path");
 
-const sNodeExecutable = process.execPath;
 const sProjectRoot = process.cwd();
 
-const sConversationApiBootstrapFile = path.resolve(sProjectRoot, "chatbot-conversation-api", "bootstrap.js");
-const oConversationApiProcess = spawn(sNodeExecutable, [sConversationApiBootstrapFile]);
+const sConversationApiAppFile = path.resolve(sProjectRoot, "chatbot-conversation-api", "app.js");
+const sConversationApiEnvironmentsFile = path.resolve(sProjectRoot, "chatbot-conversation-api", "config", "environments.js");
+const oConversationApi = require(sConversationApiAppFile);
+const oConversationApiConfig = require(sConversationApiEnvironmentsFile)[process.env.NODE_ENV];
 
-oConversationApiProcess.stdout.on("data", (data) => {
-	process.stdout.write("[CONV] " + data);
-});
+if (oConversationApiConfig == undefined || oConversationApiConfig.port == undefined || oConversationApiConfig.address == undefined) {
+    throw "[FATAL] Required conversation API configuration not found! Check config/environments.js and NODE_ENV environment variable."
+}
 
-oConversationApiProcess.stderr.on("data", (data) => {
-	process.stderr.write("[CONV] " + data);
-});
+const sManagementApiAppFile = path.resolve(sProjectRoot, "chatbot-management-api", "app.js");
+const sManagementApiEnvironmentsFile = path.resolve(sProjectRoot, "chatbot-management-api", "config", "environments.js");
+const oManagementApi = require(sManagementApiAppFile);
+const oManagementApiConfig = require(sManagementApiEnvironmentsFile)[process.env.NODE_ENV];
 
-const sManagementApiBootstrapFile = path.resolve(sProjectRoot, "chatbot-management-api", "bootstrap.js");
-const oManagementApiProcess = spawn(sNodeExecutable, [sManagementApiBootstrapFile]);
+if (oManagementApiConfig == undefined || oManagementApiConfig.port == undefined || oManagementApiConfig.address == undefined) {
+    throw "[FATAL] Required management API configuration not found! Check config/environments.js and NODE_ENV environment variable."
+}
 
-oManagementApiProcess.stdout.on("data", (data) => {
-	process.stdout.write("[MGMT] " + data);
-});
+oConversationApi.listen(oConversationApiConfig.port, oConversationApiConfig.address);
+oManagementApi.listen(oManagementApiConfig.port, oManagementApiConfig.address);
 
-oManagementApiProcess.stderr.on("data", (data) => {
-	process.stderr.write("[MGMT] " + data);
-});
+console.log("[INFO] In " + process.env.NODE_ENV + " mode");
+console.log("[INFO] Conversation API listening on port " + oConversationApiConfig.port + " bound to address " + oConversationApiConfig.address);
+console.log("[INFO] Management API listening on port " + oManagementApiConfig.port + " bound to address " + oManagementApiConfig.address);

--- a/chatbot-conversation-api/app.js
+++ b/chatbot-conversation-api/app.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/*
+ * Configure and prepare the Conversation API app for use.
+ */
+
+const express = require("express");
+const oApp = express();
+
+// load middleware
+const bodyParser = require("body-parser");
+oApp.use(bodyParser.json());
+
+// load routes
+const oRoutes = require("./config/routes");
+oRoutes.configureRoutes(oApp);
+
+module.exports = oApp;

--- a/chatbot-conversation-api/bootstrap.js
+++ b/chatbot-conversation-api/bootstrap.js
@@ -11,17 +11,7 @@
  *				Valid values are "development" and "production".
  */
 
-
-const express = require("express");
-const oApp = express();
-
-// load middleware
-const bodyParser = require("body-parser");
-oApp.use(bodyParser.json());
-
-// load routes
-const oRoutes = require("./config/routes");
-oRoutes.configureRoutes(oApp);
+const oApp = require("./app");
 
 // load environment
 const oEnvironment = require("./config/environments")[process.env.NODE_ENV];

--- a/chatbot-management-api/app.js
+++ b/chatbot-management-api/app.js
@@ -1,0 +1,18 @@
+"use strict";
+
+/*
+ * Configure and prepare the Management API app for use.
+ */
+
+const express = require("express");
+const oApp = express();
+
+// load middleware
+const bodyParser = require("body-parser");
+oApp.use(bodyParser.json());
+
+// load routes
+const oRoutes = require("./config/routes");
+oRoutes.configureRoutes(oApp);
+
+module.exports = oApp;


### PR DESCRIPTION
This commit brings the entire application, including conversation and
management APIs, into a single node process, while maintaining logical
separation. To the outside world (and even to the APIs themselves),
this change should be superficial; however, it will make deploying on
Heroku easier.